### PR TITLE
Refactor/food selection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
   env: {
     browser: true,
     node: true,
+    es6: true,
   },
   extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:prettier/recommended'],
   settings: {

--- a/mock-api.json
+++ b/mock-api.json
@@ -132,10 +132,10 @@
   "meal": [
     {
       "id": 1,
-      "category": "일식",
-      "name": "덮밥류",
-      "content": "선택지 많은 데로 가자~",
-      "img": "food/텐동.jpeg"
+      "category": "한식",
+      "name": "찌개류",
+      "content": "집밥이 그리운 날엔",
+      "img": "food/부대찌개.jpeg"
     },
     {
       "id": 2,
@@ -160,10 +160,10 @@
     },
     {
       "id": 5,
-      "category": "한식",
-      "name": "찌개류",
-      "content": "집밥이 그리운 날엔",
-      "img": "food/부대찌개.jpeg"
+      "category": "일식",
+      "name": "덮밥류",
+      "content": "선택지 많은 데로 가자~",
+      "img": "food/텐동.jpeg"
     },
     {
       "id": 6,

--- a/src/components/CartModal.jsx
+++ b/src/components/CartModal.jsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 import PickedCard from 'components/PickedCard';
 
+const COEAT = 'COEAT';
+const NOEAT = 'NOEAT';
+
 function CartModal({ coEatList, noEatList, toggleModal }) {
   return (
     <StyledCartWrapper>
@@ -11,31 +14,13 @@ function CartModal({ coEatList, noEatList, toggleModal }) {
             <span>COEAT</span>
             <StyledUnderLine COEAT />
           </StyledTitle>
-          <span>{Object.keys(coEatList).length}</span>
+          <span>{coEatList.length}</span>
         </div>
-        <ul>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-        </ul>
+        <StyledList>
+          {coEatList.map((coEatFood) => (
+            <PickedCard type={COEAT} name={coEatFood.name} img={coEatFood.img} key={coEatFood.id} />
+          ))}
+        </StyledList>
       </StyledListWrapper>
       <StyledListWrapper>
         <div>
@@ -43,22 +28,13 @@ function CartModal({ coEatList, noEatList, toggleModal }) {
             <span>NOEAT</span>
             <StyledUnderLine NOEAT />
           </StyledTitle>
-          <span>{Object.keys(noEatList).length}</span>
+          <span>{noEatList.length}</span>
         </div>
-        <ul>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-          <li>
-            <PickedCard />
-          </li>
-        </ul>
+        <StyledList>
+          {noEatList.map((noEatFood) => (
+            <PickedCard type={NOEAT} name={noEatFood.name} img={noEatFood.img} key={noEatFood.id} />
+          ))}
+        </StyledList>
       </StyledListWrapper>
     </StyledCartWrapper>
   );
@@ -70,7 +46,7 @@ const StyledCartWrapper = styled.div`
   display: flex;
   position: absolute;
   bottom: 9.2rem;
-  height: 68.9rem;
+  height: 85rem;
   width: 100%;
   background-color: #f4f5f6;
   font-size: 8rem;
@@ -94,6 +70,7 @@ const StyledTitle = styled.header`
   line-height: 2.2rem;
   margin-right: 2.1rem;
   color: black;
+  font-family: 'Montserrat';
 `;
 
 const StyledUnderLine = styled.div`
@@ -118,16 +95,13 @@ const StyledListWrapper = styled.div`
     text-align: center;
     margin-top: 4.6rem;
     color: ${(prop) => (prop.COEAT ? '#ff912d' : 'black')};
-  }
 
-  & > ul {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
-
-    & > li + li {
-      margin-left: 1rem;
-    }
+    margin-bottom: 5.2rem;
   }
+`;
+
+const StyledList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
 `;

--- a/src/components/FoodSelectionCard.jsx
+++ b/src/components/FoodSelectionCard.jsx
@@ -171,8 +171,8 @@ const BasicButton = styled.button`
 `;
 
 const CoEatButton = styled(BasicButton)`
-  background-color: ${colors.orange};
-  color: ${colors.white};
+  background-color: ${colors.lightOrange};
+  color: ${colors.orange};
 `;
 const NoEatButton = styled(BasicButton)`
   background-color: ${colors.gray};

--- a/src/components/FoodSelectionCard.jsx
+++ b/src/components/FoodSelectionCard.jsx
@@ -3,18 +3,19 @@ import { ReactComponent as Plate } from 'assets/img/plate.svg';
 import { colors } from 'constants/colors';
 
 function FoodSelectionCard(props) {
-  const { data, setCoEatList, setNoEatList } = props;
+  const { data, addCoEat, addNoEat } = props;
+  const { name, content, img, id } = data;
   return (
     <StyledCard>
       <UpBox>
         <CardWrapper>
-          <CardName>{data.name}</CardName>
-          <CardDesc>{data.content}</CardDesc>
+          <CardName>{name}</CardName>
+          <CardDesc>{content}</CardDesc>
         </CardWrapper>
         <ImageWrapper>
           <Plate />
           <MainDish>
-            <img src={`${process.env.PUBLIC_URL}/${data.img}`} alt="food-img" />
+            <img src={`${process.env.PUBLIC_URL}/${img}`} alt="food-img" />
           </MainDish>
         </ImageWrapper>
       </UpBox>
@@ -22,18 +23,8 @@ function FoodSelectionCard(props) {
         <InvertedBorder left />
         <InvertedBorder right />
         <ButtonWrapper>
-          <CoEatButton
-            onClick={() => {
-              setCoEatList((list) => ({ ...list, [data.id]: (list[data.id] || 0) + 1 }));
-            }}>
-            COEAT
-          </CoEatButton>
-          <NoEatButton
-            onClick={() => {
-              setNoEatList((list) => ({ ...list, [data.id]: (list[data.id] || 0) + 1 }));
-            }}>
-            NOEAT
-          </NoEatButton>
+          <CoEatButton onClick={() => addCoEat(id, name, img)}>COEAT</CoEatButton>
+          <NoEatButton onClick={() => addNoEat(id, name, img)}>NOEAT</NoEatButton>
         </ButtonWrapper>
       </DownBox>
     </StyledCard>
@@ -141,9 +132,9 @@ const DownBox = styled.div`
   align-items: center;
 `;
 
-const ImageWrapper = styled.div`
+export const ImageWrapper = styled.div`
   position: relative;
-  padding-top: calc(14rem + 2rem);
+  padding-top: calc(13.5rem + 2rem);
   width: 100%;
 
   display: flex;
@@ -188,7 +179,7 @@ const NoEatButton = styled(BasicButton)`
   color: ${colors.darkGray};
 `;
 
-const MainDish = styled.div`
+export const MainDish = styled.div`
   position: absolute;
   top: 0;
   width: 100%;

--- a/src/components/PickCartNav.jsx
+++ b/src/components/PickCartNav.jsx
@@ -8,14 +8,6 @@ import { colors } from 'constants/colors';
 function PickCartModal({ coEatList, noEatList, isOpen, toggleModal }) {
   const navigator = useNavigate();
 
-  const getTotalEatList = (list) => {
-    let sum = 0;
-    Object.keys(list).forEach((key) => {
-      sum += list[key];
-    });
-    return sum;
-  };
-
   return (
     <>
       <StyledCartNavWrapper>
@@ -28,9 +20,9 @@ function PickCartModal({ coEatList, noEatList, isOpen, toggleModal }) {
           <StyledLine />
           <StyledCartInfo>
             <span>COEAT</span>
-            <span>{getTotalEatList(coEatList)}</span>
+            <span>{coEatList.length}</span>
             <span>NOEAT</span>
-            <span>{getTotalEatList(noEatList)}</span>
+            <span>{noEatList.length}</span>
           </StyledCartInfo>
           <StyledOpenModalBtn onClick={() => toggleModal(!isOpen)}>
             <CartlBtnIcon />

--- a/src/components/PickedCard.jsx
+++ b/src/components/PickedCard.jsx
@@ -1,37 +1,47 @@
 import styled, { css } from 'styled-components';
-import { ReactComponent as HambugerImg } from 'assets/hambuger.svg';
-import { ReactComponent as CloseBtnImg } from 'assets/closeBtn.svg';
+import { ImageWrapper, MainDish } from './FoodSelectionCard';
 import { colors } from 'constants/colors';
+import { ReactComponent as CloseBtnImg } from 'assets/closeBtn.svg';
+import { ReactComponent as Plate } from 'assets/img/plate.svg';
 
-function PickedCard() {
+const COEAT = 'COEAT';
+
+function PickedCard(props) {
+  const { name, img, type } = props;
+  const getPublicImagePath = () => `${process.env.PUBLIC_URL}/${img}`;
   return (
     <StyledMenuSelection>
       <LeftBox>
-        <div>
-          <HambugerImg />
-          <div>
-            <span>햄버거</span>
-            <div>COEAT</div>
-          </div>
-        </div>
+        <StyledImageWrapper>
+          <StyledPlate />
+          <StyledMainDish>
+            <img src={getPublicImagePath()} alt="picked-food-img" />
+          </StyledMainDish>
+        </StyledImageWrapper>
+
+        <FoodInfoWrapper>
+          <h2>{name}</h2>
+          <FoodInfoBadge badgeType={type}>{type}</FoodInfoBadge>
+        </FoodInfoWrapper>
       </LeftBox>
       <RightBox>
         <InvertedBorder top />
         <InvertedBorder bottom />
-        <CloseBtnImg />
+        <CloseBtn>
+          <CloseBtnImg />
+        </CloseBtn>
       </RightBox>
     </StyledMenuSelection>
   );
 }
 
-const StyledMenuSelection = styled.article`
+const StyledMenuSelection = styled.li`
   display: flex;
   width: 38rem;
   height: 16.844rem;
   border-radius: 8px;
   background-color: #fff;
   border: 1px solid ${colors.cardBorder};
-  margin-top: 5.2rem;
 `;
 
 const InvertedBorder = styled.i`
@@ -89,33 +99,6 @@ const LeftBox = styled.div`
   justify-content: flex-start;
 
   border-right: 1px dashed ${colors.cardBorder};
-
-  div {
-    display: flex;
-    align-items: center;
-
-    & > svg {
-      width: 17.1rem;
-    }
-
-    & > div {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      font-size: 2.8rem;
-
-      & > div {
-        width: 10rem;
-        height: 3.811rem;
-        border: 0;
-        margin-top: 1.2rem;
-        font-size: 1.6rem;
-        font-weight: 700;
-        color: #fff;
-        background-color: ${colors.darkOrange};
-      }
-    }
-  }
 `;
 const RightBox = styled.div`
   position: relative;
@@ -123,6 +106,65 @@ const RightBox = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  padding: 0 2rem;
+`;
+
+const FoodInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 2.8rem;
+
+  gap: 1rem;
+
+  & > h2 {
+    font-family: 'Pretendard Variable';
+    font-weight: bold;
+    letter-spacing: -0.01rem;
+  }
+`;
+
+const FoodInfoBadge = styled.div`
+  font-family: 'Montserrat';
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 10rem;
+  height: 3.811rem;
+  border: 0;
+
+  font-size: 1.6rem;
+  font-weight: 700;
+
+  color: ${colors.white};
+  background-color: ${(props) => (props.badgeType === COEAT ? colors.darkOrange : colors.black)};
+`;
+
+const StyledMainDish = styled(MainDish)`
+  & > img {
+    width: 10rem;
+    height: 10rem;
+  }
+`;
+
+const StyledPlate = styled(Plate)`
+  width: 66px;
+  height: 66px;
+`;
+
+const StyledImageWrapper = styled(ImageWrapper)`
+  padding-top: calc(10rem + 2rem);
+  margin: 0;
+  width: 50%;
+`;
+
+const CloseBtn = styled.button`
+  border: none;
+  background-color: transparent;
 
   & > svg {
     width: 3rem;

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -1,6 +1,6 @@
 export const colors = {
   orange: '#FF7A00',
-  lightOrange: '#FFF1EB',
+  lightOrange: '#FFEFE0',
   darkOrange: '#FF912D',
   black: '#000000',
   gray: '#F5F5F5',

--- a/src/pages/PickPage.jsx
+++ b/src/pages/PickPage.jsx
@@ -59,7 +59,7 @@ function PickPage() {
           <div className="categories">
             <div className="category">
               {CATEGORIES.map((category, idx) => (
-                <div onClick={handleClick} key={idx}>
+                <div onClick={handleClick} key={idx} className={category === selectCtg ? 'selected' : ''}>
                   {category}
                 </div>
               ))}
@@ -152,10 +152,15 @@ const StyledContainer = styled.div`
     border-bottom: 0.5rem solid ${colors.white};
   }
 
-  .category div:hover {
-    color: ${colors.orange};
+  .category > div.selected {
     border-bottom: 0.5rem solid ${colors.orange};
+    color: ${colors.orange};
     font-weight: 700;
+  }
+
+  .category div:hover {
+    transform: scale(1.1);
+    cursor: pointer;
   }
   .search {
     display: flex;

--- a/src/pages/PickPage.jsx
+++ b/src/pages/PickPage.jsx
@@ -9,6 +9,9 @@ import useAPI from 'cores/hooks/useAPI';
 import { colors } from 'constants/colors';
 import { MEAL_CATEGORIES, COFFEE_CATEGORIES } from 'constants/categories';
 
+const COEAT = 'coeat';
+const NOEAT = 'noeat';
+
 function PickPage() {
   const containerRef = useRef(null);
   const location = useLocation();
@@ -21,10 +24,22 @@ function PickPage() {
   });
 
   const [selectCtg, setSelectCtg] = useState(CATEGORIES[0]);
-  const [coEatList, setCoEatList] = useState({});
-  const [noEatList, setNoEatList] = useState({});
+  const [coEatList, setCoEatList] = useState([]);
+  const [noEatList, setNoEatList] = useState([]);
 
   const [isOpen, setIsOpen] = useState(false);
+
+  const isDuplicatedFoodId = (foodId, list) => new Set(list.map((elem) => elem.id)).has(foodId);
+
+  const addFoodToList = (type) => {
+    return (foodId, foodName, foodImg) => {
+      const list = type === COEAT ? coEatList : noEatList;
+      const setter = type === COEAT ? setCoEatList : setNoEatList;
+
+      if (isDuplicatedFoodId(foodId, list)) return;
+      setter([...list, { id: foodId, name: foodName, img: foodImg }]);
+    };
+  };
 
   const toggleModal = () => setIsOpen(!isOpen);
 
@@ -59,20 +74,20 @@ function PickPage() {
       <section>
         <div className="wrapper_section">
           {showCtg()}
-          <article className="ctgFoods">
+          <div className="ctgFoods">
             {data &&
               !loading &&
               data
-                .filter((drink) => drink.category === selectCtg)
-                .map((drinkInfo) => (
+                .filter((food) => food.category === selectCtg)
+                .map((foodInfo) => (
                   <FoodSelectionCard
-                    key={drinkInfo.id}
-                    setCoEatList={setCoEatList}
-                    setNoEatList={setNoEatList}
-                    data={drinkInfo}
+                    key={foodInfo.id}
+                    addCoEat={addFoodToList(COEAT)}
+                    addNoEat={addFoodToList(NOEAT)}
+                    data={foodInfo}
                   />
                 ))}
-          </article>
+          </div>
         </div>
       </section>
       <PickeCartNav


### PR DESCRIPTION
### 음식 고르는 로직 변경 
* 객체에 담는 방식이 아닌 COEAT 배열과 NOEAT 배열안에 음식의 ID를 담는 방식으로 변경.
* COEAT, NOEAT 배열에는 음식의 ID와 음식의 이름 음식의 이미지URL이 담겨있음.

### PickPage 메뉴 나열 방식 변경
* 카테고리를 클릭했을 때 해당 카테고리의 음식을 보여주는 것이 아닌 한번에 모든 음식을 보여줌.
* 카테고리를 클릭했을 때 해당 카테고리가 위치한 곳으로 스크롤 이동.

### 기타 
* COEAT 버튼 색상 변경.
* 카테고리 호버 시 border가 생기면서 옆의 요소와 높이가 달라지는 버그 수정.
* 카테고리 호버 시 scale 효과 삽입.
* `Set` 사용을 위해 ESLint env 속성에 es6 추가 

