### PR TITLE
Feat/set-responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-modal": "^3.14.4",
-    "react-responsive": "9.0.0-beta.4",
+    "react-responsive": "9.0.0-beta.6",
     "react-router-dom": "6.0.2",
     "react-scripts": "4.0.3",
     "styled-components": "5.3.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import RoomProvider from 'cores/contexts/RoomProvider';
 import GlobalStyle from 'styles/globalStyle';
+import { ThemeProvider } from 'styled-components';
+import media from 'styles/mediaQueries';
 import Router from './router';
 
 function App() {
@@ -7,7 +9,9 @@ function App() {
     <>
       <GlobalStyle />
       <RoomProvider>
-        <Router />
+        <ThemeProvider theme={media}>
+          <Router />
+        </ThemeProvider>
       </RoomProvider>
     </>
   );

--- a/src/components/common/Responsive.jsx
+++ b/src/components/common/Responsive.jsx
@@ -1,0 +1,16 @@
+import useMedia from 'cores/hooks/useMedia';
+
+function Responsive(props) {
+  const { children, mobile, tablet, desktop } = props;
+  const { isMobile, isTablet, isDesktop } = useMedia();
+
+  let shouldRender = false;
+
+  if (mobile) shouldRender = shouldRender || isMobile;
+  if (tablet) shouldRender = shouldRender || isTablet;
+  if (desktop) shouldRender = shouldRender || isDesktop;
+
+  return <>{shouldRender && children}</>;
+}
+
+export default Responsive;

--- a/src/constants/deviceInfo.js
+++ b/src/constants/deviceInfo.js
@@ -1,0 +1,5 @@
+export const deviceInfo = {
+  mobile: '(max-width:459px)',
+  tablet: '(min-width:460px) and (max-width: 1023px)',
+  desktop: '(min-width:1024px)',
+};

--- a/src/cores/hooks/useMedia.jsx
+++ b/src/cores/hooks/useMedia.jsx
@@ -1,0 +1,20 @@
+import { deviceInfo } from 'constants/deviceInfo';
+import { useMediaQuery } from 'react-responsive';
+
+function useMedia() {
+  const isMobile = useMediaQuery({
+    query: deviceInfo.mobile,
+  });
+
+  const isTablet = useMediaQuery({
+    query: deviceInfo.tablet,
+  });
+
+  const isDesktop = useMediaQuery({
+    query: deviceInfo.desktop,
+  });
+
+  return { isMobile, isTablet, isDesktop };
+}
+
+export default useMedia;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -9,6 +9,8 @@ import { useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import { requestEnterGroup } from 'libs/api';
 import useRoomInfo from 'cores/hooks/useRoomInfo';
+import Responsive from 'components/common/Responsive';
+import { applyMediaQuery } from 'styles/mediaQueries';
 
 const MainPage = () => {
   const [isHost, setIsHost] = useState(false);
@@ -56,7 +58,9 @@ const MainPage = () => {
     <StyledContainer>
       <StyledMainHeader>
         <StyledTitle>
-          <Sticker />
+          <Responsive desktop tablet>
+            <Sticker />
+          </Responsive>
           <Coeat />
         </StyledTitle>
         <StyledContent>
@@ -112,6 +116,10 @@ export const StyledContainer = styled.section`
   justify-content: space-between;
   width: 100%;
   margin: 0 auto;
+  ${applyMediaQuery('mobile')} {
+    padding: 0 10%;
+    justify-content: space-around;
+  }
   height: 100%;
 `;
 
@@ -121,13 +129,22 @@ export const StyledMainHeader = styled.header`
 
 export const StyledTitle = styled.div`
   display: flex;
+  justify-content: center;
   align-items: center;
-  margin-right: 8rem;
-  margin-bottom: 4.2rem;
 
   & > svg:first-child {
     width: 15rem;
     height: 15rem;
+  }
+
+  ${applyMediaQuery('mobile')} {
+    margin-right: 0;
+    margin-bottom: 0;
+
+    & > svg:first-child {
+      width: 20rem;
+      height: 20rem;
+    }
   }
 `;
 
@@ -159,6 +176,15 @@ const StyledMainBody = styled.article`
     position: relative;
     top: 1rem;
   }
+
+  ${applyMediaQuery('mobile')} {
+    margin-top: 0;
+
+    & > svg {
+      width: 25%;
+      top: 6rem;
+    }
+  }
 `;
 
 const StyledBodyContent = styled.div`
@@ -166,6 +192,10 @@ const StyledBodyContent = styled.div`
   flex-direction: column;
   align-items: center;
   width: 68rem;
+
+  ${applyMediaQuery('mobile')} {
+    width: 100%;
+  }
   border: 1.5rem solid #f5f5f5;
   border-radius: 4rem;
 `;
@@ -187,12 +217,28 @@ const StyledBodyTitle = styled.div`
     font-weight: 700;
     margin-right: 10rem;
   }
+  ${applyMediaQuery('mobile')} {
+    & > span {
+      margin-right: 0;
+      font-family: 'Montserrat';
+      letter-spacing: -0.1rem;
+    }
+
+    & > svg {
+      width: 5.5rem;
+      height: 5.5rem;
+    }
+  }
 `;
 
 const StyledBodyDesc = styled.div`
   display: flex;
   flex-direction: column;
   margin-top: 6.1rem;
+
+  ${applyMediaQuery('mobile')} {
+    margin-top: 3rem;
+  }
 `;
 
 const StyledCoeat = styled.div`
@@ -202,13 +248,23 @@ const StyledCoeat = styled.div`
   justify-content: space-between;
   margin-bottom: 4.3rem;
 
+  ${applyMediaQuery('mobile')} {
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+  }
+
   font-size: 2.4rem;
   font-weight: 400;
   line-height: 2.8rem;
 `;
 
 const StyledLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-right: 7.4rem;
+
   .subtitle {
     font-size: 1.8rem;
     color: #888;
@@ -217,6 +273,18 @@ const StyledLeft = styled.div`
   & > p {
     & > em {
       font-weight: 700;
+    }
+  }
+
+  ${applyMediaQuery('mobile')} {
+    margin: 0;
+
+    & > p {
+      text-align: center;
+    }
+
+    .subtitle {
+      font-size: 2.1rem;
     }
   }
 `;
@@ -230,6 +298,13 @@ const StyledRight = styled.div`
   font-weight: 700;
   position: relative;
   top: -1rem;
+
+  ${applyMediaQuery('mobile')} {
+    width: fit-content;
+    text-align: center;
+    font-size: 2.5rem;
+    padding: 2.5rem 4rem;
+  }
 `;
 
 export const StyledMainButton = styled.button`

--- a/src/styles/mediaQueries.js
+++ b/src/styles/mediaQueries.js
@@ -1,0 +1,17 @@
+import { deviceInfo } from 'constants/deviceInfo';
+
+const { mobile, tablet, desktop } = deviceInfo;
+
+const deviceMediaQuery = {
+  mobile: `screen and ${mobile}`,
+  tablet: `screen and ${tablet}`,
+  desktop: `screen and ${desktop}`,
+};
+
+export const applyMediaQuery = (device) => `@media ${deviceMediaQuery[device]}`;
+
+const media = {
+  device: deviceMediaQuery,
+};
+
+export default media;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9927,10 +9927,10 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-responsive@9.0.0-beta.4:
-  version "9.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.4.tgz#90c1f1a4048971497ca9795068af6803eabc0ddb"
-  integrity sha512-jQSs5kIi38T39Ku98r8s75jM6JAaNEeVrHPHTrL2EYWuv8nusV3KRQcZZ4VlfwndIRedxmpb4T8FXA9ltlCFiw==
+react-responsive@9.0.0-beta.6:
+  version "9.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.6.tgz#78dcc9c2af3b176dfa4088dae617a73dba8adbe7"
+  integrity sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==
   dependencies:
     hyphenate-style-name "^1.0.0"
     matchmediaquery "^0.3.0"


### PR DESCRIPTION
## 반응형 작업을 위한 세팅

변경사항

* react-responsive 라이브러리 설치
* 위 라이브러리를 사용해서 useMedia 커스텀 훅 구현
* 위 훅을 사용해서 `Responsive` 라는 컴포넌트 구현 
```javascript 
// Some 이라는 컴포넌트는 모바일에 해당하는 디바이스 너비일때만 나타남.
<>
    <EveryDeviceComponent />
    <Responsive mobile>
         <Some />
    </Responsive>
</>
```
* `applyMediaQuery` 메서드를 구현하여 styled-components 내부에서도 반응형 코드를 작성할 수 있게함.
* 테스트 삼아 메인페이지만 반응형 작업을 진행해보았습니다.


> `Responsive` 컴포넌트와 `applyMediaQuery` 메소드에 관한 자세한 설명은 [링크](https://www.notion.so/storypanda/850a50a08d284cbbb5c326a82fd9a582)를 참조하길 바랍니다
